### PR TITLE
Use function-relative line numbering

### DIFF
--- a/jsonsplit_test.go
+++ b/jsonsplit_test.go
@@ -54,7 +54,7 @@ func equalTypes[Want any](t *testing.T, got any) {
 
 // callerPlus adjusts file:line as file:line+n.
 func callerPlus(s string, n int) string {
-	if i := strings.LastIndexByte(s, ':') + len(":"); i > 0 {
+	if i := strings.LastIndexAny(s, ":+") + len(":"); i > 0 {
 		if m, err := strconv.Atoi(s[i:]); err == nil {
 			s = s[:i] + strconv.Itoa(m+n)
 		}


### PR DESCRIPTION
The file:line notation is less useful when different versions of a binary are being deployed as the lines become stale relatively quickly with even minor modifications to the source file.

The function-relative line numbering is more stable, which is why the Go telemeny service uses this notation. See https://research.swtch.com/telemetry-design